### PR TITLE
Error while importing

### DIFF
--- a/Data Preprocessing and Embeddings/Text_Classification_using_ML.ipynb
+++ b/Data Preprocessing and Embeddings/Text_Classification_using_ML.ipynb
@@ -42,9 +42,9 @@
         "from keras.models import Model\n",
         "from keras.layers import LSTM, Activation, Dense, Dropout, Input, Embedding, SpatialDropout1D\n",
         "from keras.optimizers import RMSprop\n",
-        "from keras.preprocessing.text import Tokenizer\n",
-        "from keras.preprocessing import sequence\n",
-        "from keras.utils import to_categorical\n",
+        "from tensorflow.keras.preprocessing.text import Tokenizer\n",
+        "from tensorflow.keras.preprocessing import sequence\n",
+        "from tensorflow.keras.utils import to_categorical\n"
         "from keras.callbacks import EarlyStopping, ModelCheckpoint\n",
         "from keras.models import Sequential\n",
         "from keras.utils import pad_sequences\n",


### PR DESCRIPTION
"ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-d46ad8aa3460> in <cell line: 17>()
     15 from keras.layers import LSTM, Activation, Dense, Dropout, Input, Embedding, SpatialDropout1D
     16 from keras.optimizers import RMSprop
---> 17 from keras.preprocessing.text import Tokenizer
     18 from keras.preprocessing import sequence
     19 from keras.utils import to_categorical "


THIS WAS THE ERROR 
ModuleNotFoundError: No module named 'keras.preprocessing.text' occurs because the module keras.preprocessing.text has been moved or removed in recent versions of TensorFlow/Keras
 NEED TO REPLACE
"from keras.preprocessing.text import Tokenizer
from keras.preprocessing import sequence
from keras.utils import to_categorical"
WITH
"from tensorflow.keras.preprocessing.text import Tokenizer from tensorflow.keras.preprocessing import sequence from tensorflow.keras.utils import to_categorical"

thank you for the video it has been a great learning ,please make the changes and accept my pull request